### PR TITLE
[데이] 예외 핸들러 구현

### DIFF
--- a/be/src/main/java/issuetracker/be/controller/IssueController.java
+++ b/be/src/main/java/issuetracker/be/controller/IssueController.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,12 +56,12 @@ public class IssueController {
     return issueService.getFilteredIssue(filterRequest);
   }
 
-  @PutMapping("/issue/open")
+  @PatchMapping("/issue/open")
   public void openIssues(@RequestBody OpenStatusChangeRequest openStatusChangeRequest) {
     issueService.changeIssueStatus(openStatusChangeRequest, true);
   }
 
-  @PutMapping("/issue/close")
+  @PatchMapping("/issue/close")
   public void closeIssue(@RequestBody OpenStatusChangeRequest openStatusChangeRequest) {
     issueService.changeIssueStatus(openStatusChangeRequest, false);
   }

--- a/be/src/main/java/issuetracker/be/exception/CustomExceptionHandler.java
+++ b/be/src/main/java/issuetracker/be/exception/CustomExceptionHandler.java
@@ -1,0 +1,28 @@
+package issuetracker.be.exception;
+
+import java.util.NoSuchElementException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+  @ExceptionHandler(value = {MilestoneHasAssociatedIssuesException.class,
+      NoSuchElementException.class})
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ExceptionResponse handleBusinessLogicException(Exception e) {
+    log.error("{} : {}", e.getClass().getName(), e.getMessage());
+    return new ExceptionResponse(e.getMessage());
+  }
+
+  @ExceptionHandler(Exception.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  public ExceptionResponse handleGlobalException(Exception e) {
+    log.error("{} : {}", e.getClass().getName(), e.getMessage());
+    return new ExceptionResponse("예상하지 못한 오류입니다. 다시 시도해 주세요.");
+  }
+}

--- a/be/src/main/java/issuetracker/be/exception/ExceptionResponse.java
+++ b/be/src/main/java/issuetracker/be/exception/ExceptionResponse.java
@@ -1,0 +1,7 @@
+package issuetracker.be.exception;
+
+public record ExceptionResponse(
+    String description
+) {
+
+}

--- a/be/src/main/java/issuetracker/be/service/IssueService.java
+++ b/be/src/main/java/issuetracker/be/service/IssueService.java
@@ -129,7 +129,7 @@ public class IssueService {
   @Transactional
   public void changeIssueStatus(OpenStatusChangeRequest openStatusChangeRequest, boolean status) {
     openStatusChangeRequest.id().stream()
-        .map(i -> issueRepository.findById(i).orElseThrow())
+        .map(this::getIssue)
         .forEach(i -> {
           i.setIs_open(status);
           issueRepository.save(i);
@@ -138,7 +138,7 @@ public class IssueService {
 
   private Issue getIssue(Long issueId) {
     return issueRepository.findById(issueId)
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이슈입니다."));
+        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 이슈입니다."));
   }
 
   private MilestoneWithIssueCountResponse getMilestoneWithIssueCountResponse(Issue issue) {


### PR DESCRIPTION
- 예외를 처리하는 핸들러를 구현했습니다.
- 막상 구현을 하니까 각 예외 종류들마다 핸들러에서 다르게 처리할만한 거리가 많지 않았습니다. 그래서 일단 서비스하는 동안 발생할 수 있는 에러들을 하나로 묶어서 400 으로 응답하도록 설정해두었습니다.
- 특정 예외 뿐 아니라, 다른 모든 예외들도 동일한 형식(ExceptionResponse)으로 응답하고 싶어 나머지 Exception을 다 catch해서 500 으로 응답하도록 설정했습니다.
```
{
  "description": "존재하지 않는 이슈입니다."
}
```
- 위와 같은 JSON 형식으로 body를 만들어 응답합니다.